### PR TITLE
Remove style attribute from cycle_ajax.php

### DIFF
--- a/cycle_ajax.php
+++ b/cycle_ajax.php
@@ -122,7 +122,7 @@ if (sizeof($graphs)) {
 
 		$out .= '<td align="center" class="graphholder">'
 			. '<a href = ../../graph.php?local_graph_id='.$graph['graph_id'].'&rra_id=all>'
-			. "<img style='width:" . $width . "px;height:" . $height . "px' "
+			. "<img "
 			. "src='../../graph_image.php?image_format=png&disable_cache=true&local_graph_id=" . $graph['graph_id'] . "&rra_id=0&graph_start=" . $timespan['begin_now']
 			. '&graph_end=' . time() . '&graph_width=' . $width . '&graph_height=' . $height . ($legend==0 || $legend=='' ? '&graph_nolegend=true' : '')."'>"
 			. '</a></td>';


### PR DESCRIPTION
The style attribute isn't working as expected as the rrdtool returns dynamic sized images and the height and width settings provided to rrdtool are only defining the actual graph area not including the title or any legends added or anything else surounding the charting arey.