### PR TITLE
get_request_var using wrong legend parameter

### DIFF
--- a/cycle.php
+++ b/cycle.php
@@ -37,7 +37,7 @@ validate_request_vars();
 
 general_header();
 
-$legend = get_request_var('cycle_legend');
+$legend = get_request_var('legend');
 
 ?>
 <center><!-- Timespan - Refresh - Prev - Stop - Next links -->


### PR DESCRIPTION
This fixes Issue #3. The get_reqest_var is actually loading cycle_legend when given the parameter of "legend" ( see validate_request_vars )