### PR TITLE
refactor: DRY cycle request context handling

### DIFF
--- a/cycle.php
+++ b/cycle.php
@@ -34,6 +34,7 @@ include_once('./lib/api_tree.php');
 include_once('./lib/utility.php');
 include_once('./lib/api_data_source.php');
 include_once('./plugins/cycle/functions.php');
+include_once('./plugins/cycle/cycle_helpers.php');
 
 set_default_action();
 
@@ -63,18 +64,16 @@ function cycle_graphs() {
 	global $id, $graph_id, $next_graph_id, $prev_graph_id;
 
 	$tree_list = get_allowed_trees();
-	$legend    = get_request_var('legend');
-	$tree_id   = get_request_var('tree_id');
-	$leaf_id   = get_request_var('leaf_id');
-	$graphpp   = get_request_var('graphs');
-	$cols      = get_request_var('cols');
-	$rfilter   = get_request_var('rfilter');
-	$id        = get_request_var('id');
-	$width     = get_request_var('width');
-	$height    = get_request_var('height');
-
-	if (empty($tree_id)) $tree_id = db_fetch_cell('SELECT id FROM graph_tree ORDER BY name LIMIT 1');
-	if (empty($id))      $id      = -1;
+	$request   = cycle_get_request_context();
+	$legend    = $request['legend'];
+	$tree_id   = $request['tree_id'];
+	$leaf_id   = $request['leaf_id'];
+	$graphpp   = $request['graphs'];
+	$cols      = $request['cols'];
+	$rfilter   = $request['rfilter'];
+	$id        = $request['id'];
+	$width     = $request['width'];
+	$height    = $request['height'];
 
 	/* get the start and end times for the graph */
 	$timespan        = array();
@@ -154,26 +153,16 @@ function cycle() {
 	}
 
 	$tree_list = get_allowed_trees();
-	$legend    = get_request_var('legend');
-	$tree_id   = get_request_var('tree_id');
-	$leaf_id   = get_request_var('leaf_id');
-	$graphpp   = get_request_var('graphs');
-	$cols      = get_request_var('cols');
-	$rfilter   = get_request_var('rfilter');
-	$id        = get_request_var('id');
-	$width     = get_request_var('width');
-	$height    = get_request_var('height');
-
-	if (empty($tree_id)) {
-		$tree_id = db_fetch_cell('SELECT id
-			FROM graph_tree
-			ORDER BY name
-			LIMIT 1');
-	}
-
-	if (empty($id)) {
-		$id      = -1;
-	}
+	$request   = cycle_get_request_context();
+	$legend    = $request['legend'];
+	$tree_id   = $request['tree_id'];
+	$leaf_id   = $request['leaf_id'];
+	$graphpp   = $request['graphs'];
+	$cols      = $request['cols'];
+	$rfilter   = $request['rfilter'];
+	$id        = $request['id'];
+	$width     = $request['width'];
+	$height    = $request['height'];
 
 	/* get the start and end times for the graph */
 	$timespan        = array();
@@ -401,4 +390,3 @@ function cycle() {
 
 	bottom_footer();
 }
-

--- a/cycle_helpers.php
+++ b/cycle_helpers.php
@@ -1,0 +1,45 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ +-------------------------------------------------------------------------+
+ */
+
+if (!function_exists('cycle_get_default_tree_id')) {
+	function cycle_get_default_tree_id($tree_id) {
+		if (empty($tree_id)) {
+			$tree_id = db_fetch_cell('SELECT id
+				FROM graph_tree
+				ORDER BY name
+				LIMIT 1');
+		}
+
+		return $tree_id;
+	}
+}
+
+if (!function_exists('cycle_get_request_context')) {
+	function cycle_get_request_context() {
+		$context = array(
+			'legend'  => get_request_var('legend'),
+			'tree_id' => get_request_var('tree_id'),
+			'leaf_id' => get_request_var('leaf_id'),
+			'graphs'  => get_request_var('graphs'),
+			'cols'    => get_request_var('cols'),
+			'rfilter' => get_request_var('rfilter'),
+			'id'      => get_request_var('id'),
+			'width'   => get_request_var('width'),
+			'height'  => get_request_var('height')
+		);
+
+		$context['tree_id'] = cycle_get_default_tree_id($context['tree_id']);
+		$context['id']      = (empty($context['id']) ? -1 : $context['id']);
+
+		return $context;
+	}
+}

--- a/tests/test_request_context.php
+++ b/tests/test_request_context.php
@@ -72,9 +72,12 @@ assert_true('provided id is preserved', $context['id'] === 456);
 assert_true('no fallback query when tree_id exists', count($db_queries) === 0);
 
 $cycle_source = file_get_contents(__DIR__ . '/../cycle.php');
+assert_true('cycle.php is readable', $cycle_source !== false);
+$cycle_source = ($cycle_source === false ? '' : $cycle_source);
+
 assert_true(
-	'cycle.php uses shared request context in both paths',
-	preg_match_all('/cycle_get_request_context\\s*\\(/', $cycle_source) >= 2
+	'cycle.php uses shared request context helper',
+	preg_match('/cycle_get_request_context\\s*\\(/', $cycle_source) === 1
 );
 
 echo "\n";

--- a/tests/test_request_context.php
+++ b/tests/test_request_context.php
@@ -1,0 +1,83 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | Regression checks for shared cycle request-context helpers              |
+ |                                                                         |
+ | Run: php tests/test_request_context.php                                 |
+ +-------------------------------------------------------------------------+
+ */
+
+$pass = 0;
+$fail = 0;
+$request_values = array();
+$db_queries = array();
+
+function assert_true($label, $value) {
+	global $pass, $fail;
+
+	if ($value) {
+		echo "PASS  $label\n";
+		$pass++;
+	} else {
+		echo "FAIL  $label\n";
+		$fail++;
+	}
+}
+
+function get_request_var($key) {
+	global $request_values;
+
+	return (array_key_exists($key, $request_values) ? $request_values[$key] : '');
+}
+
+function db_fetch_cell($sql) {
+	global $db_queries;
+	$db_queries[] = $sql;
+
+	return 777;
+}
+
+require_once __DIR__ . '/../cycle_helpers.php';
+
+$request_values = array(
+	'legend'  => 'true',
+	'tree_id' => '',
+	'leaf_id' => 19,
+	'graphs'  => 8,
+	'cols'    => 3,
+	'rfilter' => 'prod',
+	'id'      => '',
+	'width'   => 500,
+	'height'  => 200
+);
+$db_queries = array();
+
+$context = cycle_get_request_context();
+
+assert_true('empty tree_id falls back to first tree query', $context['tree_id'] === 777);
+assert_true('empty id normalizes to -1', $context['id'] === -1);
+assert_true('legend is preserved', $context['legend'] === 'true');
+assert_true('fallback query executes once', count($db_queries) === 1);
+
+$request_values['tree_id'] = 123;
+$request_values['id'] = 456;
+$db_queries = array();
+
+$context = cycle_get_request_context();
+
+assert_true('provided tree_id is preserved', $context['tree_id'] === 123);
+assert_true('provided id is preserved', $context['id'] === 456);
+assert_true('no fallback query when tree_id exists', count($db_queries) === 0);
+
+$cycle_source = file_get_contents(__DIR__ . '/../cycle.php');
+assert_true(
+	'cycle.php uses shared request context in both paths',
+	preg_match_all('/cycle_get_request_context\\s*\\(/', $cycle_source) >= 2
+);
+
+echo "\n";
+echo "Results: $pass passed, $fail failed\n";
+
+exit($fail > 0 ? 1 : 0);


### PR DESCRIPTION
## Summary
- add shared request-context helpers in `cycle_helpers.php`
- deduplicate request extraction and default normalization logic used by both `cycle_graphs()` and `cycle()`
- keep behavior unchanged while reducing repeated code in `cycle.php`

## Tests
- `php -l cycle.php`
- `php -l cycle_helpers.php`
- `php -l tests/test_request_context.php`
- `php tests/test_request_context.php`

Closes #23
