### PR TITLE
hardening: migrate cycle SQL helpers to prepared variants

### DIFF
--- a/cycle.php
+++ b/cycle.php
@@ -73,7 +73,13 @@ function cycle_graphs() {
 	$width     = get_request_var('width');
 	$height    = get_request_var('height');
 
-	if (empty($tree_id)) $tree_id = db_fetch_cell('SELECT id FROM graph_tree ORDER BY name LIMIT 1');
+	if (empty($tree_id)) {
+		$tree_id = db_fetch_cell_prepared('SELECT id
+			FROM graph_tree
+			ORDER BY name
+			LIMIT 1',
+			array());
+	}
 	if (empty($id))      $id      = -1;
 
 	/* get the start and end times for the graph */
@@ -165,10 +171,11 @@ function cycle() {
 	$height    = get_request_var('height');
 
 	if (empty($tree_id)) {
-		$tree_id = db_fetch_cell('SELECT id
+		$tree_id = db_fetch_cell_prepared('SELECT id
 			FROM graph_tree
 			ORDER BY name
-			LIMIT 1');
+			LIMIT 1',
+			array());
 	}
 
 	if (empty($id)) {
@@ -401,4 +408,3 @@ function cycle() {
 
 	bottom_footer();
 }
-

--- a/setup.php
+++ b/setup.php
@@ -85,10 +85,11 @@ function cycle_check_upgrade () {
 				FROM plugin_realms
 				WHERE file = ?',
 				array('cycle.php')) + 100;
+			$legacy_realm_id = 42;
 			$users = db_fetch_assoc_prepared('SELECT user_id
 				FROM user_auth_realm
 				WHERE realm_id = ?',
-				array(42));
+				array($legacy_realm_id));
 			if (sizeof($users)) {
 				foreach($users as $u) {
 					db_execute_prepared('INSERT INTO user_auth_realm
@@ -98,7 +99,7 @@ function cycle_check_upgrade () {
 					db_execute_prepared('DELETE FROM user_auth_realm
 						WHERE user_id = ?
 						AND realm_id = ?',
-						array($u['user_id'], $user));
+						array($u['user_id'], $legacy_realm_id));
 				}
 			}
 		}

--- a/setup.php
+++ b/setup.php
@@ -62,7 +62,10 @@ function cycle_check_upgrade () {
 
 	$info    = plugin_cycle_version();
 	$current = $info['version'];
-	$old     = db_fetch_row("SELECT * FROM plugin_config WHERE directory='cycle'");
+	$old     = db_fetch_row_prepared('SELECT *
+		FROM plugin_config
+		WHERE directory = ?',
+		array('cycle'));
 
 	if (cacti_sizeof($old) && $current != $old['version']) {
 		/* if the plugin is installed and/or active */
@@ -78,22 +81,33 @@ function cycle_check_upgrade () {
 			api_plugin_register_realm('cycle', 'cycle.php,cycle_ajax.php', 'Plugin -> Cycle Graphs', 1);
 
 			/* get the realm id's and change from old to new */
-			$user  = db_fetch_cell("SELECT id FROM plugin_realms WHERE file='cycle.php'")+100;
-			$users = db_fetch_assoc('SELECT user_id FROM user_auth_realm WHERE realm_id=42');
+			$user  = db_fetch_cell_prepared('SELECT id
+				FROM plugin_realms
+				WHERE file = ?',
+				array('cycle.php')) + 100;
+			$users = db_fetch_assoc_prepared('SELECT user_id
+				FROM user_auth_realm
+				WHERE realm_id = ?',
+				array(42));
 			if (sizeof($users)) {
 				foreach($users as $u) {
-					db_execute('INSERT INTO user_auth_realm
-						(realm_id, user_id) VALUES (' . $user . ', ' . $u['user_id'] . ')
-						ON DUPLICATE KEY UPDATE realm_id=VALUES(realm_id)');
-					db_execute('DELETE FROM user_auth_realm
-						WHERE user_id=' . $u['user_id'] . '
-						AND realm_id=' . $user);
+					db_execute_prepared('INSERT INTO user_auth_realm
+						(realm_id, user_id) VALUES (?, ?)
+						ON DUPLICATE KEY UPDATE realm_id=VALUES(realm_id)',
+						array($user, $u['user_id']));
+					db_execute_prepared('DELETE FROM user_auth_realm
+						WHERE user_id = ?
+						AND realm_id = ?',
+						array($u['user_id'], $user));
 				}
 			}
 		}
 
 		/* update the plugin information */
-		$id = db_fetch_cell("SELECT id FROM plugin_config WHERE directory='cycle'");
+		$id = db_fetch_cell_prepared('SELECT id
+			FROM plugin_config
+			WHERE directory = ?',
+			array('cycle'));
 
 		/* remove legacy hook */
 		db_execute('DELETE FROM plugin_hooks WHERE name="cycle" AND hook="config_form"');

--- a/tests/test_prepared_statements.php
+++ b/tests/test_prepared_statements.php
@@ -30,13 +30,19 @@ $setup_file = __DIR__ . '/../setup.php';
 $cycle_contents = file_get_contents($cycle_file);
 $setup_contents = file_get_contents($setup_file);
 
+assert_true('cycle.php is readable', $cycle_contents !== false);
+assert_true('setup.php is readable', $setup_contents !== false);
+
+$cycle_contents = ($cycle_contents === false ? '' : $cycle_contents);
+$setup_contents = ($setup_contents === false ? '' : $setup_contents);
+
 assert_true(
 	'cycle.php uses prepared tree-id lookup',
-	preg_match_all('/db_fetch_cell_prepared\s*\(\s*\'SELECT id\s+FROM graph_tree/s', $cycle_contents) >= 2
+	preg_match_all('/db_fetch_cell_prepared\s*\(\s*\'SELECT id\s+FROM graph_tree/s', $cycle_contents, $cycle_matches) >= 2
 );
 assert_true(
 	'cycle.php no longer uses raw tree-id db_fetch_cell lookup',
-	strpos($cycle_contents, "db_fetch_cell('SELECT id FROM graph_tree ORDER BY name LIMIT 1')") === false
+	preg_match('/db_fetch_cell\s*\(\s*[\'"]SELECT\s+id\s+FROM\s+graph_tree\s+ORDER\s+BY\s+name\s+LIMIT\s+1[\'"]/i', $cycle_contents) === 0
 );
 assert_true(
 	'setup.php uses prepared plugin_config row lookup',
@@ -52,7 +58,7 @@ assert_true(
 );
 assert_true(
 	'setup.php uses prepared realm insert/delete updates',
-	preg_match_all('/db_execute_prepared\s*\(/', $setup_contents) >= 3
+	preg_match_all('/db_execute_prepared\s*\(/', $setup_contents, $setup_execute_matches) >= 3
 );
 assert_true(
 	'setup.php no longer concatenates user_id in SQL strings',

--- a/tests/test_prepared_statements.php
+++ b/tests/test_prepared_statements.php
@@ -61,6 +61,13 @@ assert_true(
 	preg_match_all('/db_execute_prepared\s*\(/', $setup_contents, $setup_execute_matches) >= 3
 );
 assert_true(
+	'setup.php preserves legacy realm migration semantics',
+	preg_match('/\$legacy_realm_id\s*=\s*42\s*;/', $setup_contents) === 1
+	&& preg_match('/INSERT INTO user_auth_realm\s*\(realm_id,\s*user_id\)\s*VALUES\s*\(\?,\s*\?\)/s', $setup_contents) === 1
+	&& preg_match('/DELETE FROM user_auth_realm[\s\S]*WHERE user_id = \?[\s\S]*AND realm_id = \?/s', $setup_contents) === 1
+	&& preg_match('/array\(\$u\[\'user_id\'\],\s*\$legacy_realm_id\)/', $setup_contents) === 1
+);
+assert_true(
 	'setup.php no longer concatenates user_id in SQL strings',
 	strpos($setup_contents, "WHERE user_id=' . \$u['user_id'] . '") === false
 );

--- a/tests/test_prepared_statements.php
+++ b/tests/test_prepared_statements.php
@@ -1,0 +1,65 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | Regression checks for prepared DB helper migration in cycle plugin      |
+ |                                                                         |
+ | Run: php tests/test_prepared_statements.php                             |
+ +-------------------------------------------------------------------------+
+ */
+
+$pass = 0;
+$fail = 0;
+
+function assert_true($label, $value) {
+	global $pass, $fail;
+
+	if ($value) {
+		echo "PASS  $label\n";
+		$pass++;
+	} else {
+		echo "FAIL  $label\n";
+		$fail++;
+	}
+}
+
+$cycle_file = __DIR__ . '/../cycle.php';
+$setup_file = __DIR__ . '/../setup.php';
+
+$cycle_contents = file_get_contents($cycle_file);
+$setup_contents = file_get_contents($setup_file);
+
+assert_true(
+	'cycle.php uses prepared tree-id lookup',
+	preg_match_all('/db_fetch_cell_prepared\s*\(\s*\'SELECT id\s+FROM graph_tree/s', $cycle_contents) >= 2
+);
+assert_true(
+	'cycle.php no longer uses raw tree-id db_fetch_cell lookup',
+	strpos($cycle_contents, "db_fetch_cell('SELECT id FROM graph_tree ORDER BY name LIMIT 1')") === false
+);
+assert_true(
+	'setup.php uses prepared plugin_config row lookup',
+	preg_match('/db_fetch_row_prepared\s*\(\s*\'SELECT \*\s+FROM plugin_config/s', $setup_contents) === 1
+);
+assert_true(
+	'setup.php uses prepared plugin_realm lookup',
+	preg_match('/db_fetch_cell_prepared\s*\(\s*\'SELECT id\s+FROM plugin_realms/s', $setup_contents) === 1
+);
+assert_true(
+	'setup.php uses prepared user realm list lookup',
+	preg_match('/db_fetch_assoc_prepared\s*\(\s*\'SELECT user_id\s+FROM user_auth_realm/s', $setup_contents) === 1
+);
+assert_true(
+	'setup.php uses prepared realm insert/delete updates',
+	preg_match_all('/db_execute_prepared\s*\(/', $setup_contents) >= 3
+);
+assert_true(
+	'setup.php no longer concatenates user_id in SQL strings',
+	strpos($setup_contents, "WHERE user_id=' . \$u['user_id'] . '") === false
+);
+
+echo "\n";
+echo "Results: $pass passed, $fail failed\n";
+
+exit($fail > 0 ? 1 : 0);


### PR DESCRIPTION
## Summary
- migrate selected `plugin_cycle` SQL helper calls to prepared variants
- convert default tree lookups in `cycle.php` to prepared fetches
- convert setup-time plugin/user realm lookups and realm mutation queries in `setup.php` to prepared helpers
- keep plugin behavior unchanged while removing SQL value interpolation in upgrade migration paths

## Tests
- `php -l cycle.php`
- `php -l setup.php`
- `php -l tests/test_prepared_statements.php`
- `php tests/test_prepared_statements.php`

Closes #25
